### PR TITLE
Fix improper MemberSelectExpression tree casting in UseConstantsForHttpCodesRule  rule

### DIFF
--- a/src/main/java/ix/ibm/sonar/java/visitors/HttpCodeFinder.java
+++ b/src/main/java/ix/ibm/sonar/java/visitors/HttpCodeFinder.java
@@ -16,17 +16,13 @@
 
 package ix.ibm.sonar.java.visitors;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import lombok.Getter;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
-import org.sonar.plugins.java.api.tree.LiteralTree;
-import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
-import org.sonar.plugins.java.api.tree.MethodInvocationTree;
+import org.sonar.plugins.java.api.tree.*;
 
-import lombok.Getter;
+import java.util.ArrayList;
+import java.util.List;
 
 import static ix.ibm.sonar.java.utils.PackageConstants.SLING_HTTP_SERVLET_RESPONSE;
 
@@ -40,10 +36,14 @@ public class HttpCodeFinder extends BaseTreeVisitor {
 
     @Override
     public void visitMethodInvocation(final MethodInvocationTree tree) {
+        final String methodName = tree.symbol().name();
+        String expressionFqn = StringUtils.EMPTY;
+        if (tree.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
+            expressionFqn = ((MemberSelectExpressionTree) tree.methodSelect()).expression().symbolType().fullyQualifiedName();
+        }
 
-        final String methodName = ((MemberSelectExpressionTree) tree.methodSelect()).identifier().symbol().name();
         this.isSetHttpSlingResponseStatus = StringUtils.equals(SET_STATUS, methodName) && StringUtils.equals(
-          SLING_HTTP_SERVLET_RESPONSE, ((MemberSelectExpressionTree) tree.methodSelect()).expression().symbolType().fullyQualifiedName());
+          SLING_HTTP_SERVLET_RESPONSE, expressionFqn);
         super.visitMethodInvocation(tree);
         this.isSetHttpSlingResponseStatus = false;
     }

--- a/src/test/files/sling/UseConstantsForHttpCodesCheck.java
+++ b/src/test/files/sling/UseConstantsForHttpCodesCheck.java
@@ -15,7 +15,11 @@
  */
 
 import javax.servlet.Servlet;
+
 import org.apache.sling.api.SlingHttpServletResponse;
+
+import javax.servlet.http.HttpServletResponse;
+
 
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
@@ -66,6 +70,34 @@ public class CustomServlet2 extends SlingAllMethodsServlet {
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
 
+    }
+
+}
+
+@Component(service = Servlet.class, immediate = true)
+@SlingServletResourceTypes(resourceTypes = "resourceType", selectors = "selector")
+public class CustomServlet3 extends SlingAllMethodsServlet {
+
+    private static final int NUMBER_OF_COMPONENTS_PER_JOB = 100;
+
+    @Reference
+    private transient EmailService emailService;
+
+    @Override
+    protected void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response) {
+        final List<String> failureList = this.emailService.sendEmail(templatePath, emailParams, TARGET_EMAIL_ADDRESS);
+
+        customMethodCall();
+
+        if (failureList.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_OK);
+        } else {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String customMethodCall() {
+        return "a";
     }
 
 }


### PR DESCRIPTION
During analysis, errors were being thrown for _UseConstantsForHttpCodesRule_ rule due to unchecked casting of the _tree_ object.