### PR TITLE
Update dependencies and set support to min 9.9 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,10 +56,9 @@
     </issueManagement>
 
     <properties>
-        <sonar.version>8.9.0.43852</sonar.version>
-        <sslr.version>1.24.0.633</sslr.version>
-        <junit.version>5.8.0</junit.version>
-        <sonarjava.version>7.1.0.26670</sonarjava.version>
+        <sonar.api.version>9.14.0.375</sonar.api.version>
+        <junit.version>5.10.1</junit.version>
+        <sonarjava.version>7.28.0.33738</sonarjava.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <sonar.organization>ibm-ix-aem-sonarqube-rules</sonar.organization>
@@ -68,53 +67,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.sonarsource.sonarqube</groupId>
+            <groupId>org.sonarsource.api.plugin</groupId>
             <artifactId>sonar-plugin-api</artifactId>
-            <version>${sonar.version}</version>
+            <version>${sonar.api.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>org.sonarsource.java</groupId>
             <artifactId>sonar-java-plugin</artifactId>
             <type>sonar-plugin</type>
             <version>${sonarjava.version}</version>
             <scope>provided</scope>
-        </dependency>
-
-        <!-- Required since SonarQube > 8.1 -->
-        <dependency>
-            <groupId>org.sonarsource.sonarqube</groupId>
-            <artifactId>sonar-plugin-api-impl</artifactId>
-            <version>${sonar.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.sonarsource.sslr-squid-bridge</groupId>
-            <artifactId>sslr-squid-bridge</artifactId>
-            <version>2.7.1.392</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.sonar.sslr</groupId>
-                    <artifactId>sslr-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.sonar</groupId>
-                    <artifactId>sonar-plugin-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.sonar.sslr</groupId>
-                    <artifactId>sslr-xpath</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>jcl-over-slf4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -127,14 +90,7 @@
         <dependency>
             <groupId>org.sonarsource.analyzer-commons</groupId>
             <artifactId>sonar-analyzer-commons</artifactId>
-            <version>1.22.0.848</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.sonarsource.sslr</groupId>
-            <artifactId>sslr-testing-harness</artifactId>
-            <version>${sslr.version}</version>
-            <scope>test</scope>
+            <version>2.3.0.1263</version>
         </dependency>
 
         <dependency>
@@ -146,13 +102,13 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1.1-jre</version>
+            <version>31.1-jre</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.5</version>
         </dependency>
 
         <dependency>
@@ -169,23 +125,16 @@
             <scope>test</scope>
         </dependency>
 
-
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.20.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.2.6</version>
+            <version>3.24.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.26</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -205,7 +154,7 @@
             <plugin>
                 <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
                 <artifactId>sonar-packaging-maven-plugin</artifactId>
-                <version>1.21.0.505</version>
+                <version>1.23.0.740</version>
                 <extensions>true</extensions>
                 <configuration>
                     <pluginKey>ibmixaemrules</pluginKey>
@@ -214,14 +163,14 @@
                     <pluginUrl>https://github.com/IBM/ibm-ix-aem-sonarqube-plugin</pluginUrl>
                     <sonarLintSupported>true</sonarLintSupported>
                     <skipDependenciesPackaging>true</skipDependenciesPackaging>
-                    <sonarQubeMinVersion>8.9</sonarQubeMinVersion>
+                    <pluginApiMinVersion>9.9</pluginApiMinVersion>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.5.1</version>
                 <configuration>
                 </configuration>
                 <executions>
@@ -237,7 +186,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>
@@ -248,7 +197,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.10</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>copy</id>

--- a/src/main/java/ix/ibm/sonar/java/MyJavaRulesDefinition.java
+++ b/src/main/java/ix/ibm/sonar/java/MyJavaRulesDefinition.java
@@ -16,13 +16,14 @@
 
 package ix.ibm.sonar.java;
 
+import org.sonar.api.SonarRuntime;
+import org.sonar.api.server.rule.RulesDefinition;
+import org.sonarsource.analyzer.commons.RuleMetadataLoader;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
-
-import org.sonar.api.server.rule.RulesDefinition;
-import org.sonarsource.analyzer.commons.RuleMetadataLoader;
 
 /**
  * Declare rule metadata in server repository of rules.
@@ -39,11 +40,17 @@ public class MyJavaRulesDefinition implements RulesDefinition {
     // Add the rule keys of the rules which need to be considered as template-rules
     private static final Set<String> RULE_TEMPLATES_KEY = Collections.emptySet();
 
+    private final SonarRuntime runtime;
+
+    public MyJavaRulesDefinition(SonarRuntime runtime) {
+        this.runtime = runtime;
+    }
+
     @Override
     public void define(Context context) {
         NewRepository repository = context.createRepository(REPOSITORY_KEY, "java").setName(REPOSITORY_NAME);
 
-        RuleMetadataLoader ruleMetadataLoader = new RuleMetadataLoader(RESOURCE_BASE_PATH);
+        RuleMetadataLoader ruleMetadataLoader = new RuleMetadataLoader(RESOURCE_BASE_PATH, this.runtime);
 
         ruleMetadataLoader.addRulesByAnnotatedClass(repository, new ArrayList<>(RulesList.getChecks()));
 

--- a/src/main/java/ix/ibm/sonar/java/checks/osgi/AvoidJcrApiRule.java
+++ b/src/main/java/ix/ibm/sonar/java/checks/osgi/AvoidJcrApiRule.java
@@ -16,15 +16,14 @@
 
 package ix.ibm.sonar.java.checks.osgi;
 
+import ix.ibm.sonar.java.utils.JavaFinder;
+import ix.ibm.sonar.java.utils.PackageConstants;
+import ix.ibm.sonar.java.visitors.ExpandedTreeVisitor;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
-
-import ix.ibm.sonar.java.utils.JavaFinder;
-import ix.ibm.sonar.java.utils.PackageConstants;
-import ix.ibm.sonar.java.visitors.ExpandedTreeVisitor;
 
 @Rule(key = "AvoidJcrApi")
 public class AvoidJcrApiRule extends ExpandedTreeVisitor {
@@ -33,7 +32,7 @@ public class AvoidJcrApiRule extends ExpandedTreeVisitor {
 
     @Override
     public void visitMethodInvocation(final MethodInvocationTree tree) {
-        final String fullyQualifiedName = JavaFinder.getEnclosingClassName(tree.symbol()).orElse(StringUtils.EMPTY);
+        final String fullyQualifiedName = JavaFinder.getEnclosingClassName(tree.methodSymbol()).orElse(StringUtils.EMPTY);
 
         if (StringUtils.equals(fullyQualifiedName, PackageConstants.JCR_NODE) || StringUtils.equals(
           fullyQualifiedName, PackageConstants.JCR_SESSION)) {

--- a/src/main/java/ix/ibm/sonar/java/visitors/FindSessionDeclarationVisitor.java
+++ b/src/main/java/ix/ibm/sonar/java/visitors/FindSessionDeclarationVisitor.java
@@ -22,22 +22,13 @@
 
 package ix.ibm.sonar.java.visitors;
 
+import org.sonar.plugins.java.api.tree.*;
+import org.sonar.plugins.java.api.tree.Tree.Kind;
+
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-
-import org.sonar.plugins.java.api.tree.AssignmentExpressionTree;
-import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
-import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
-import org.sonar.plugins.java.api.tree.MethodInvocationTree;
-import org.sonar.plugins.java.api.tree.MethodTree;
-import org.sonar.plugins.java.api.tree.ReturnStatementTree;
-import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.plugins.java.api.tree.Tree.Kind;
-import org.sonar.plugins.java.api.tree.TryStatementTree;
-import org.sonar.plugins.java.api.tree.VariableTree;
 
 /**
  * Finds all injector variable declarations. Used in method's bodies only.
@@ -121,7 +112,7 @@ public class FindSessionDeclarationVisitor extends BaseTreeVisitor {
     }
 
     private boolean isSlingRepository(final MethodInvocationTree methodInvocation) {
-        return methodInvocation.symbol().owner().type().fullyQualifiedName().equals(SLING_REPOSITORY);
+        return methodInvocation.methodSymbol().owner().type().fullyQualifiedName().equals(SLING_REPOSITORY);
     }
 
     private boolean isSession(final MethodInvocationTree methodInvocation) {

--- a/src/main/java/ix/ibm/sonar/java/visitors/HttpCodeFinder.java
+++ b/src/main/java/ix/ibm/sonar/java/visitors/HttpCodeFinder.java
@@ -36,7 +36,7 @@ public class HttpCodeFinder extends BaseTreeVisitor {
 
     @Override
     public void visitMethodInvocation(final MethodInvocationTree tree) {
-        final String methodName = tree.symbol().name();
+        final String methodName = tree.methodSymbol().name();
         String expressionFqn = StringUtils.EMPTY;
         if (tree.methodSelect().is(Tree.Kind.MEMBER_SELECT)) {
             expressionFqn = ((MemberSelectExpressionTree) tree.methodSelect()).expression().symbolType().fullyQualifiedName();

--- a/src/main/java/ix/ibm/sonar/java/visitors/PrinterVisitor.java
+++ b/src/main/java/ix/ibm/sonar/java/visitors/PrinterVisitor.java
@@ -16,14 +16,13 @@
 
 package ix.ibm.sonar.java.visitors;
 
-import java.util.List;
-import java.util.Objects;
-
-import javax.annotation.Nullable;
-
 import org.apache.commons.lang.StringUtils;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.Tree;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Objects;
 
 public class PrinterVisitor extends BaseTreeVisitor {
 
@@ -66,7 +65,7 @@ public class PrinterVisitor extends BaseTreeVisitor {
                   .indent()
                   .append(nodeName)
                   .append(" :")
-                  .append(tree.firstToken().line())
+                  .append(tree.firstToken().range().start().line())
                   .append(" | ")
                   .append(tree.firstToken().text())
                   .append("\n");

--- a/src/test/java/ix/ibm/sonar/java/MockedSonarRuntime.java
+++ b/src/test/java/ix/ibm/sonar/java/MockedSonarRuntime.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020-present IBM Corporation
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package ix.ibm.sonar.java;
+
+import org.sonar.api.SonarEdition;
+import org.sonar.api.SonarProduct;
+import org.sonar.api.SonarQubeSide;
+import org.sonar.api.SonarRuntime;
+import org.sonar.api.utils.Version;
+
+public class MockedSonarRuntime implements SonarRuntime {
+
+    @Override
+    public Version getApiVersion() {
+        return Version.create(9, 9);
+    }
+
+    @Override
+    public SonarProduct getProduct() {
+        return SonarProduct.SONARQUBE;
+    }
+
+    @Override
+    public SonarQubeSide getSonarQubeSide() {
+        return SonarQubeSide.SCANNER;
+    }
+
+    @Override
+    public SonarEdition getEdition() {
+        return SonarEdition.COMMUNITY;
+    }
+}

--- a/src/test/java/ix/ibm/sonar/java/MyJavaRulesDefinitionTest.java
+++ b/src/test/java/ix/ibm/sonar/java/MyJavaRulesDefinitionTest.java
@@ -32,7 +32,7 @@ class MyJavaRulesDefinitionTest {
   @Test
   @DisplayName("GIVEN a MyJavaRulesDefinition, WHEN defining a context, THEN the created rules definition repository should contain the 'AEM ecx.io rules' name and be part of the java language")
   void test() {
-    final MyJavaRulesDefinition rulesDefinition = new MyJavaRulesDefinition();
+    final MyJavaRulesDefinition rulesDefinition = new MyJavaRulesDefinition(new MockedSonarRuntime());
     final RulesDefinition.Context context = new RulesDefinition.Context();
     rulesDefinition.define(context);
     final RulesDefinition.Repository repository = context.repository(MyJavaRulesDefinition.REPOSITORY_KEY);


### PR DESCRIPTION
Update dependencies and set the minimum supported version to the latest LTS (9.9), minor tweaks where needed to stop using deprecated methods
