### PR TITLE
Add support for on-demand plugin download in SonarQube

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
                     <sonarLintSupported>true</sonarLintSupported>
                     <skipDependenciesPackaging>true</skipDependenciesPackaging>
                     <pluginApiMinVersion>9.9</pluginApiMinVersion>
+                    <requiredForLanguages>java</requiredForLanguages>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Added a _requiredForLanguages_ configuration that adds the _Plugin-RequiredForLanguages_ property to the Manifest file, which in turn enables the new SonarQube feature for automatic plugin download during scanning.

More info about the feature available here: https://community.sonarsource.com/t/the-sonarscanners-download-only-required-3rd-party-plugins/108156